### PR TITLE
utilise tf sans avoir a faire de broadcaster

### DIFF
--- a/launch/wm_frame_to_box.launch
+++ b/launch/wm_frame_to_box.launch
@@ -2,8 +2,8 @@
 
 <launch>
 
-    <param name="minimum_distance"      type="double"   value="0.2" />
-    <param name="maximum_distance"      type="double"   value="50" />
+    <param name="minimum_distance"      type="double"   value="0.5" />
+    <param name="maximum_distance"      type="double"   value="20" />
     <param name="auto_publisher"        type="bool"     value="false" />
     <param name="camera_topic"          type="string"   value="/head_xtion/depth/image_raw" />
     <param name="camera_frame"          type="string"   value="head_xtion_depth_frame" />


### PR DESCRIPTION
rend la méthode de transformation plus propre et aussi plus stable.
On avais des troubles avec la synchronisation des tfs avant. Ce n'est plus le cas puisqu'on n'utilise plus de broadcaster. On utilise plutôt directement les fonctions de la librairie TF.

testé sur sara: ça marche à date.