### PR TITLE
Feature/lookup past

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Lancer le launchfile avec
 Reçoit le depth de la camera et les cadres publiés par darknet. Retourne des boites en 3d sous forme de tf et de message.
 
 
-#### Topics Souscris
+#### Topics Souscris*
 
 * **`/head_xtion/depth/image`** ([sensor_msgs/Image])
 
@@ -57,7 +57,7 @@ Reçoit le depth de la camera et les cadres publiés par darknet. Retourne des b
 
 	Les cadres 2d retournés par darknet_ros
 
-#### Topics Publiés
+#### Topics Publiés*
 
 * **`/frame_to_box/bounding_boxes`** ([wm_frame_to_box/BoundingBoxes3D])
 
@@ -69,7 +69,9 @@ Reçoit le depth de la camera et les cadres publiés par darknet. Retourne des b
 
 	Recois une depth Image et une liste de BoundingBoxes2D.
 	- sara_msgs/BoundingBoxes2D boundingBoxes2D
-	- sensor_msgs/Image Image
+	- sensor_msgs/Image image
+	- string input_frame
+	- string output_frame
 	
 	Retourne une liste des BoundingBoxes3D
 	- sara_msgs/BoundingBoxes3D boundingBoxes3D
@@ -77,7 +79,7 @@ Reçoit le depth de la camera et les cadres publiés par darknet. Retourne des b
 #### Paramètres
 * **`auto_publisher`** (bool, default: true)
 
-	Largeur en radians de l'ouverture de la camera
+	Faut-il souscrire et publier automatiquement aux topic. Le service fonctionne quand même.
 	
 * **`camera_angle_width`** (float, default: 0.785398163397)
 
@@ -87,6 +89,14 @@ Reçoit le depth de la camera et les cadres publiés par darknet. Retourne des b
 
 	Hauteur en radians de l'ouverture de la camera
 
+* **`minimum_distance`** (float, default: 0.2)
+
+	Distance minimale accepté en (m)
+
+* **`maximum_distance`** (float, default: 50)
+
+	Distance maximum accepté en (m)
+	
 * **`camera_topic`** (string, default: "/head_xtion/depth/image_raw")
 
 	Topic où aller chercher le depth de la camera
@@ -98,6 +108,10 @@ Reçoit le depth de la camera et les cadres publiés par darknet. Retourne des b
 * **`base_frame`** (string, default: "base_link")
 
 	Frame tf de référence pour le message des boites 3d
+	
+* **`frame_ag`** (float, default: 0.0)
+
+	Temps de décalage en (s) dans le passé où regarder pour les tf.
 
 * **`yolo_topic`** (string, default: "/darknet_ros/bounding_boxes")
 

--- a/launch/wm_frame_to_box.launch
+++ b/launch/wm_frame_to_box.launch
@@ -4,7 +4,7 @@
 
     <param name="minimum_distance"      type="double"   value="0.5" />
     <param name="maximum_distance"      type="double"   value="20" />
-    <param name="frame_lag"             type="double"   value="0.5" />
+    <param name="frame_lag"             type="double"   value="0.25" />
     <param name="auto_publisher"        type="bool"     value="false" />
     <param name="camera_topic"          type="string"   value="/head_xtion/depth/image_raw" />
     <param name="camera_frame"          type="string"   value="head_xtion_depth_frame" />

--- a/launch/wm_frame_to_box.launch
+++ b/launch/wm_frame_to_box.launch
@@ -4,6 +4,7 @@
 
     <param name="minimum_distance"      type="double"   value="0.5" />
     <param name="maximum_distance"      type="double"   value="20" />
+    <param name="frame_lag"             type="double"   value="0.5" />
     <param name="auto_publisher"        type="bool"     value="false" />
     <param name="camera_topic"          type="string"   value="/head_xtion/depth/image_raw" />
     <param name="camera_frame"          type="string"   value="head_xtion_depth_frame" />

--- a/src/wm_frame_to_box.cpp
+++ b/src/wm_frame_to_box.cpp
@@ -242,7 +242,7 @@ int main(int argc, char **argv) {
 
     // get all parameters
     nh.param("auto_publisher", _AUTO_PLUBLISHER, bool(true));
-    ROS_INFO("base_frame = %s", _BASE_FRAME.c_str());
+    ROS_INFO("auto_publisher = %d", _AUTO_PLUBLISHER);
     nh.param("minimum_distance", _MIN_DIST, 0.2);
     ROS_INFO("minimum_distance = %lf", _MIN_DIST);
     nh.param("maximum_distance", _MAX_DIST, 50.0);

--- a/src/wm_frame_to_box.cpp
+++ b/src/wm_frame_to_box.cpp
@@ -143,22 +143,23 @@ get_BB(cv_bridge::CvImagePtr Img, std::vector<darknet_ros_msgs::BoundingBox> BBs
 
         /*** TF frame transformation ***/
         // Create the tf point
-        tf::StampedTransform transform;
-        transform.setOrigin({px,py,pz});
+        tf::Stamped<tf::Vector3> loc;
+        loc.frame_id_ = input_frame;  // Reference frame
+        loc.setY(py);
+        loc.setZ(pz);
+        loc.setX(px);
 
         // Apply transformation to the new reference frame
         ros::Time past{ros::Time::now()-ros::Duration(_FRAME_LAG)};
+        loc.stamp_ = past;
         tfl->waitForTransform(output_frame, input_frame, past, ros::Duration(1.0));
-        tfl->lookupTransform(output_frame, input_frame, past, transform);
-
-        // extract the new coordinates
-        auto origin{transform.getOrigin()};
+        tfl->transformPoint(output_frame, loc, loc );
 
         // Generate the center of the box
         geometry_msgs::Point po;
-        po.x = origin.x();
-        po.y = origin.y();
-        po.z = origin.z();
+        po.x = loc.x();
+        po.y = loc.y();
+        po.z = loc.z();
 
         /*** Create the box ***/
         // create a box message and fill all the parameters

--- a/src/wm_frame_to_box.cpp
+++ b/src/wm_frame_to_box.cpp
@@ -23,6 +23,7 @@ bool _AUTO_PLUBLISHER;
 double _MIN_DIST;
 double _MAX_DIST;
 double _DEFAULT_BOX_SIZE;
+double _FRAME_LAG;
 std::string _BASE_FRAME;
 cv_bridge::CvImagePtr LastImage;
 ros::Publisher posePub;
@@ -146,7 +147,7 @@ get_BB(cv_bridge::CvImagePtr Img, std::vector<darknet_ros_msgs::BoundingBox> BBs
         transform.setOrigin({px,py,pz});
 
         // Apply transformation to the new reference frame
-        ros::Time past{ros::Time::now()-ros::Duration(1.0)};
+        ros::Time past{ros::Time::now()-ros::Duration(_FRAME_LAG)};
         tfl->waitForTransform(output_frame, input_frame, past, ros::Duration(1.0));
         tfl->lookupTransform(output_frame, input_frame, past, transform);
 
@@ -245,6 +246,8 @@ int main(int argc, char **argv) {
     ROS_INFO("minimum_distance = %lf", _MIN_DIST);
     nh.param("maximum_distance", _MAX_DIST, 50.0);
     ROS_INFO("maximum_distance = %lf", _MAX_DIST);
+    nh.param("frame_lag", _FRAME_LAG, 0.0);
+    ROS_INFO("frame_lag = %lf", _FRAME_LAG);
     nh.param("camera_angle_width", _CAMERA_ANGLE_WIDTH, 1.012290966);
     ROS_INFO("camera_angle_width = %f", _CAMERA_ANGLE_WIDTH);
     nh.param("camera_angle_height", _CAMERA_ANGLE_HEIGHT, 0.785398163397);


### PR DESCRIPTION
Étant donné que yolo prend beaucoup de temps à faire sa job. Il y a un décalage entre les bounding boxes et tf. Par chance, tf offre la possibilité de lire les transformations dans le passé.
cette pr ajoute la capacité de lire dans le passé pour corriger le décalage.