### PR TITLE
Feature/box dimentions

### DIFF
--- a/launch/wm_frame_to_box.launch
+++ b/launch/wm_frame_to_box.launch
@@ -4,7 +4,7 @@
 
     <param name="minimum_distance"      type="double"   value="0.5" />
     <param name="maximum_distance"      type="double"   value="20" />
-    <param name="frame_lag"             type="double"   value="0.25" />
+    <param name="frame_lag"             type="double"   value="0.0" />
     <param name="auto_publisher"        type="bool"     value="false" />
     <param name="camera_topic"          type="string"   value="/head_xtion/depth/image_raw" />
     <param name="camera_frame"          type="string"   value="head_xtion_depth_frame" />
@@ -14,6 +14,7 @@
     <param name="yolo_topic"            type="string"   value="/darknet_ros/bounding_boxes" />
     <param name="bounding_boxes_topic"  type="string"   value="/frame_to_boxes/bounding_boxes" />
     <param name="default_box_size"      type="double"   value="0.1" />
+    <param name="nb_samples"            type="int"   value="15" />
     <node name="frame_to_box" pkg="wm_frame_to_box" type="wm_frame_to_box" output="screen"/>
 
 </launch>

--- a/launch/wm_frame_to_box.launch
+++ b/launch/wm_frame_to_box.launch
@@ -4,7 +4,6 @@
 
     <param name="minimum_distance"      type="double"   value="0.5" />
     <param name="maximum_distance"      type="double"   value="20" />
-    <param name="frame_lag"             type="double"   value="0.0" />
     <param name="auto_publisher"        type="bool"     value="false" />
     <param name="camera_topic"          type="string"   value="/head_xtion/depth/image_raw" />
     <param name="camera_frame"          type="string"   value="head_xtion_depth_frame" />
@@ -14,7 +13,7 @@
     <param name="yolo_topic"            type="string"   value="/darknet_ros/bounding_boxes" />
     <param name="bounding_boxes_topic"  type="string"   value="/frame_to_boxes/bounding_boxes" />
     <param name="default_box_size"      type="double"   value="0.1" />
-    <param name="nb_samples"            type="int"   value="15" />
+    <param name="nb_samples"            type="int"      value="10" />
     <node name="frame_to_box" pkg="wm_frame_to_box" type="wm_frame_to_box" output="screen"/>
 
 </launch>

--- a/launch/wm_frame_to_box.launch
+++ b/launch/wm_frame_to_box.launch
@@ -5,6 +5,7 @@
     <param name="minimum_distance"      type="double"   value="0.5" />
     <param name="maximum_distance"      type="double"   value="20" />
     <param name="auto_publisher"        type="bool"     value="false" />
+    <param name="publish_markers"       type="bool"     value="false" />
     <param name="camera_topic"          type="string"   value="/head_xtion/depth/image_raw" />
     <param name="camera_frame"          type="string"   value="head_xtion_depth_frame" />
     <param name="base_frame"            type="string"   value="base_link" />

--- a/src/wm_frame_to_box.cpp
+++ b/src/wm_frame_to_box.cpp
@@ -246,6 +246,7 @@ get_BB(cv_bridge::CvImagePtr Img, darknet_ros_msgs::BoundingBoxes BBs, std::stri
         }
 
     }
+    boxes.header = BBs.header;
     return boxes;
 }
 

--- a/src/wm_frame_to_box.cpp
+++ b/src/wm_frame_to_box.cpp
@@ -22,7 +22,6 @@ bool _AUTO_PLUBLISHER;
 double _MIN_DIST;
 double _MAX_DIST;
 double _DEFAULT_BOX_SIZE;
-double _FRAME_LAG;
 int _NBSAMPLES{10};
 std::string _BASE_FRAME;
 cv_bridge::CvImagePtr LastImage;
@@ -185,12 +184,10 @@ get_BB(cv_bridge::CvImagePtr Img, darknet_ros_msgs::BoundingBoxes BBs, std::stri
 
 
         /*** TF frame transformation ***/
-
         // Wait for the availability of the transformation
         tf::Stamped<tf::Vector3> loc;
-        ros::Time past{ros::Time::now()-ros::Duration(_FRAME_LAG)};
-        loc.stamp_ = past;
-        tfl->waitForTransform(output_frame, input_frame, past, ros::Duration(1.0));
+        loc.stamp_ = BBs.header.stamp;
+        tfl->waitForTransform(output_frame, input_frame, BBs.header.stamp, ros::Duration(1.0));
 
 
         // Apply transformation to the new reference frame and Generate the center of the box
@@ -313,7 +310,6 @@ int main(int argc, char **argv) {
     nh.param("auto_publisher", _AUTO_PLUBLISHER, bool(true));
     nh.param("minimum_distance", _MIN_DIST, 0.2);
     nh.param("maximum_distance", _MAX_DIST, 50.0);
-    nh.param("frame_lag", _FRAME_LAG, 0.0);
     nh.param("camera_angle_width", _CAMERA_ANGLE_WIDTH, 1.012290966);
     nh.param("camera_angle_height", _CAMERA_ANGLE_HEIGHT, 0.785398163397);
     nh.param("camera_topic", _CAMERA_TOPIC, std::string("/head_xtion/depth/image_raw"));

--- a/src/wm_frame_to_box.cpp
+++ b/src/wm_frame_to_box.cpp
@@ -18,7 +18,7 @@ std::string _CAMERA_TOPIC;
 std::string _YOLO_TOPIC;
 std::string _CAMERA_FRAME;
 std::string _BOUNDING_BOXES_TOPIC;
-bool _AUTO_PLUBLISHER;
+bool _AUTO_PLUBLISHER{false};
 double _MIN_DIST;
 double _MAX_DIST;
 double _DEFAULT_BOX_SIZE;
@@ -28,6 +28,7 @@ cv_bridge::CvImagePtr LastImage;
 ros::Publisher posePub;
 tf::TransformListener *tfl;
 ros::Publisher markerPublisher;
+bool _PUBLISH_MARKERS{false};
 
 
 // Declare functions
@@ -222,9 +223,7 @@ get_BB(cv_bridge::CvImagePtr Img, darknet_ros_msgs::BoundingBoxes BBs, std::stri
         boxes.boundingBoxes.push_back(box);
 
         /*** Publish the boxes ***/
-        posePub.publish(boxes);
-
-        {  // Publish visual box
+        if (_PUBLISH_MARKERS){  // Publish visual box
             visualization_msgs::Marker m;
             m.header.stamp = ros::Time::now();
             m.lifetime = ros::Duration(0.1);
@@ -308,7 +307,7 @@ int main(int argc, char **argv) {
     ros::NodeHandle nh;
 
     // get all parameters
-    nh.param("auto_publisher", _AUTO_PLUBLISHER, bool(true));
+    nh.param("auto_publisher", _AUTO_PLUBLISHER, false);
     nh.param("minimum_distance", _MIN_DIST, 0.2);
     nh.param("maximum_distance", _MAX_DIST, 50.0);
     nh.param("camera_angle_width", _CAMERA_ANGLE_WIDTH, 1.012290966);
@@ -320,7 +319,7 @@ int main(int argc, char **argv) {
     nh.param("camera_frame", _CAMERA_FRAME, std::string("head_xtion_depth_frame"));
     nh.param("base_frame", _BASE_FRAME, std::string("/base_link"));
     nh.param("nb_samples", _NBSAMPLES, 10);
-
+    nh.param("publish_markers", _PUBLISH_MARKERS, false);
 
     // Initialise tf listener
     tfl = new tf::TransformListener(nh, ros::Duration(5) ,true);

--- a/srv/GetBoundingBoxes3D.srv
+++ b/srv/GetBoundingBoxes3D.srv
@@ -1,6 +1,6 @@
-sara_msgs/BoundingBox2D[] boundingBoxes2D
+sara_msgs/BoundingBoxes2D boundingBoxes2D
 sensor_msgs/Image image
 string input_frame
 string output_frame
 ---
-sara_msgs/BoundingBox3D[] boundingBoxes3D
+sara_msgs/BoundingBoxes3D boundingBoxes3D


### PR DESCRIPTION
Ajoute la tridification des dimentions des bounding_boxes.
On assume que les boites sont des prismes à base carré puisque l'on a pas moyen d'estimer la profondeurs des objets.

Testé sur sara: Ca marche bien.