### PR TITLE
Feature/namespace class

### DIFF
--- a/launch/wm_frame_to_box.launch
+++ b/launch/wm_frame_to_box.launch
@@ -5,7 +5,7 @@
     <param name="minimum_distance"      type="double"   value="0.5" />
     <param name="maximum_distance"      type="double"   value="20" />
     <param name="auto_publisher"        type="bool"     value="false" />
-    <param name="publish_markers"       type="bool"     value="false" />
+    <param name="publish_markers"       type="bool"     value="true" />
     <param name="camera_topic"          type="string"   value="/head_xtion/depth/image_raw" />
     <param name="camera_frame"          type="string"   value="head_xtion_depth_frame" />
     <param name="base_frame"            type="string"   value="base_link" />
@@ -14,7 +14,7 @@
     <param name="yolo_topic"            type="string"   value="/darknet_ros/bounding_boxes" />
     <param name="bounding_boxes_topic"  type="string"   value="/frame_to_boxes/bounding_boxes" />
     <param name="default_box_size"      type="double"   value="0.1" />
-    <param name="nb_samples"            type="int"      value="10" />
+    <param name="nb_samples"            type="int"      value="1" />
     <node name="frame_to_box" pkg="wm_frame_to_box" type="wm_frame_to_box" output="screen"/>
 
 </launch>

--- a/src/wm_frame_to_box.cpp
+++ b/src/wm_frame_to_box.cpp
@@ -228,7 +228,7 @@ get_BB(cv_bridge::CvImagePtr Img, darknet_ros_msgs::BoundingBoxes BBs, std::stri
             m.header.stamp = ros::Time::now();
             m.lifetime = ros::Duration(0.1);
             m.header.frame_id = "/map";
-            m.ns = "Boxes";
+            m.ns = box.Class;
             m.id = ros::Time::now().toNSec()+int(box.probability*1000);
             m.type = m.CUBE;
             m.pose.position.x = box.Center.x;


### PR DESCRIPTION
une vielle branche.
met le nom de l'objet comme namespace pour l'affichage des boites.
pratique pour quand on veux pas voir certain objets